### PR TITLE
Fix "start" command to "run" command (meteor)

### DIFF
--- a/manuals/views/step1.md
+++ b/manuals/views/step1.md
@@ -472,7 +472,7 @@ To learn more about **Mobile** in `Meteor` read the [*"Mobile"* chapter](https:/
 
 `Ionic` apps are still usable in the browser. You can run them using the command:
 
-    $ meteor start
+    $ meteor run
     # OR
     $ npm start
 


### PR DESCRIPTION
"Start" is not a available command for meteor. The command to launch the project in the browser is "run".
https://docs.meteor.com/commandline.html