### PR TITLE
Correct main.js reference

### DIFF
--- a/manuals/templates/step1.md.tmpl
+++ b/manuals/templates/step1.md.tmpl
@@ -66,7 +66,7 @@ Like most libraries, `Angular 2` is relied on peer dependencies, which we will h
 Now that we have all the compilers and their dependencies ready, we will have to transform our project files into their supported extension. `.js` files should be renamed to `.ts` files, and `.css` files should be renamed to `.scss` files.
 
     $ mv server/main.js server/main.ts
-    $ mv client/main.js client/main.ts
+    $ mv client/main.jsx client/main.ts
     $ mv client/main.css client/main.scss
 
 Last but not least, we will add some basic [Cordova](https://cordova.apache.org/) plugins which will take care of mobile specific features:


### PR DESCRIPTION
Since the command `meteor create ...` sets this up as a React app by default, there would be a `client/main.jsx` file instead of a `client/main.js`.